### PR TITLE
add line break for block level element before StartRender

### DIFF
--- a/HtmlToWord/elements/Base.py
+++ b/HtmlToWord/elements/Base.py
@@ -10,6 +10,7 @@ class BaseElement(object):
     IgnoredChildren = []
     IsIgnored = False
     soup = None
+    blockDisplay = None
 
     # StripTextAfter is used by elements that contain text, such as paragraphs. Text objects after will be stripped
     # of any whitespace
@@ -184,6 +185,7 @@ class BaseElement(object):
 
                 o = o.GetChildren()[0]
 
+        self.addLineBreak()
         self.start_pos = self.document.ActiveWindow.Selection.Start
         self.FlushPreviousFormatting()
         self.StartRender()
@@ -204,6 +206,11 @@ class BaseElement(object):
 
             self.ApplyFormatting(start_pos, end_pos)
             self.EndRender()
+
+    def addLineBreak(self):
+        isParaStart = self.selection.Start == self.selection.Paragraphs(1).Range.Start
+        if self.blockDisplay and not isParaStart:
+            self.selection.TypeParagraph()
 
     def SetParent(self, parent):
         self.parent = parent
@@ -237,6 +244,11 @@ class BaseElement(object):
         self._EndRender()
         return False
 
+class BlockElement(BaseElement):
+    blockDisplay = True
+
+class InlineElement(BaseElement):
+    blockDisplay = False
 
 class IgnoredElement(BaseElement):
     IsIgnored = True

--- a/HtmlToWord/elements/Headings.py
+++ b/HtmlToWord/elements/Headings.py
@@ -1,14 +1,11 @@
 from HtmlToWord.elements.Base import *
 
 
-class BaseHeading(BaseElement):
+class BaseHeading(BlockElement):
     StyleName = None
 
     def StartRender(self):
         self.selection.Style = self.GetDocument().Styles(self.StyleName)
-
-    def EndRender(self):
-        self.selection.TypeParagraph()
 
 
 class Heading1(BaseHeading):

--- a/HtmlToWord/elements/List.py
+++ b/HtmlToWord/elements/List.py
@@ -31,11 +31,7 @@ class List(BlockElement):
         parent = self.GetParent()
         # Here we check to see if we have a parent and if they are a listelement or a orderedlist.
         if parent is not None and parent.GetName() in self.AllowedChildren:
-            if parent.GetName() == "ListElement":
-                # Our parent is a ListElement, this means we are a nested sub-list within a <li> tag.
-                # We make a new paragraph here because there will be text above us (not a <p> element)
-                # so we need to make a new list entry below, which will then be indented.
-                self.selection.TypeParagraph()
+            # Our parent is a ListElement, this means we are a nested sub-list within a <li> tag.
             self.selection.Range.ListFormat.ListIndent()
         else:
             self.selection.Range.ListFormat.ApplyListTemplateWithLevel(
@@ -43,10 +39,14 @@ class List(BlockElement):
                 ContinuePreviousList=False,
                 DefaultListBehavior=constants.wdWord10ListBehavior
             )
-        pass
 
     def EndRender(self):
         parent = self.GetParent()
+
+        # Before outdenting or closing the list we need to be in a newline,
+        # else we will remove the last element as well
+        self.selection.TypeParagraph()
+
         if parent is not None and parent.GetName() in self.AllowedChildren:
             # If we are nested then we just outdent the list
             self.selection.Range.ListFormat.ListOutdent()
@@ -72,16 +72,5 @@ class UnorderedList(List):
         return constants.wdBulletGallery
 
 
-class ListElement(BaseElement):
+class ListElement(BlockElement):
     IgnoredChildren = ["Break"]
-
-    def EndRender(self):
-        # A bit of a hack but whatever. If the last child is a OrderedList or UnorderedList
-        # then we have a nested sub-list. Don't start a new paragraph because the List will
-        # do this for us.
-        last_child = ""
-        if len(self.GetChildren()):
-            last_child = self.GetChildren()[-1].GetName()
-
-        if not last_child in ("OrderedList", "UnorderedList"):
-            self.selection.TypeParagraph()

--- a/HtmlToWord/elements/List.py
+++ b/HtmlToWord/elements/List.py
@@ -2,7 +2,7 @@ from HtmlToWord.elements.Base import *
 from win32com.client import constants
 
 
-class List(BaseElement):
+class List(BlockElement):
     """
     I am a list, I can be ordered or unordered and I can have sub lists within me.
     There are two common ways to express sub lists using HTML and this class handles both of them:

--- a/HtmlToWord/elements/Misc.py
+++ b/HtmlToWord/elements/Misc.py
@@ -18,11 +18,11 @@ class Break(ChildlessElement):
         self.selection.TypeParagraph()
 
 
-class Div(BaseElement):
+class Div(BlockElement):
     pass
 
 
-class Span(BaseElement):
+class Span(InlineElement):
     pass
 
 
@@ -61,7 +61,7 @@ class Image(ChildlessElement):
             self.selection.TypeParagraph()
 
 
-class HyperLink(BaseElement):
+class HyperLink(InlineElement):
     # Formatting tags don't work well inside hyperlinks. Ignore them.
     IgnoredChildren = groups.FORMAT_TAGS
 

--- a/HtmlToWord/elements/Table.py
+++ b/HtmlToWord/elements/Table.py
@@ -4,7 +4,7 @@ from HtmlToWord.elements.Base import *
 from win32com.client import constants
 
 
-class Table(BaseElement):
+class Table(BlockElement):
     """
     I seem to support merged cells and rows now, but in their infinite complexity I am
     sure someone will find ways to break me. I support two types of table:

--- a/HtmlToWord/elements/Text.py
+++ b/HtmlToWord/elements/Text.py
@@ -4,7 +4,7 @@ from win32com.client import constants
 import re
 
 
-class Bold(BaseElement):
+class Bold(InlineElement):
     def StartRender(self):
         self.selection.BoldRun()
 
@@ -12,7 +12,7 @@ class Bold(BaseElement):
         self.selection.BoldRun()
 
 
-class Italic(BaseElement):
+class Italic(InlineElement):
     def StartRender(self):
         self.selection.ItalicRun()
 
@@ -20,7 +20,7 @@ class Italic(BaseElement):
         self.selection.ItalicRun()
 
 
-class UnderLine(BaseElement):
+class UnderLine(InlineElement):
     def StartRender(self):
         with self.With(self.selection.Font) as Font:
             Font.UnderlineColor = constants.wdColorAutomatic
@@ -79,7 +79,7 @@ class Text(ChildlessElement):
         return "<Text: %s>" % repr(self.Text)
 
 
-class Paragraph(BaseElement):
+class Paragraph(BlockElement):
     StripTextAfter = True
 
     def StartRender(self):
@@ -90,13 +90,9 @@ class Paragraph(BaseElement):
     def EndRender(self):
         if self.HasChild("Break"):
             self.selection.Style = self.PreviousStyle
-        # Adding a paragprah after this looks weird as the list does this itself.
-        from HtmlToWord.elements.Misc import Image
-        if not isinstance(self.GetLastChild(), (List, Image)) and self.GetParent().GetLastChild() != self:
-            self.selection.TypeParagraph()
 
 
-class Pre(BaseElement):
+class Pre(BlockElement):
     StripFirstElementText = True
     PRE_FORMATTED = True
 


### PR DESCRIPTION
add a line break before element rendering (before calling StartRender()) if it's a block-level element and  it's not the beginning of paragraph